### PR TITLE
Support for freebsd passwd(5)

### DIFF
--- a/passwd.go
+++ b/passwd.go
@@ -3,64 +3,8 @@ package shadow
 import (
 	"bufio"
 	"io"
-	"strconv"
 	"strings"
 )
-
-// A PasswdEntry represents a single entry in the passwd map.  The
-// entry uses the field names as found in `man 5 passwd`.
-type PasswdEntry struct {
-	Login    string
-	Password string
-	UID      int
-	GID      int
-	Comment  string
-	Home     string
-	Shell    string
-}
-
-func (pe PasswdEntry) String() string {
-	return pe.Login + ":" +
-		pe.Password + ":" +
-		strconv.Itoa(pe.UID) + ":" +
-		strconv.Itoa(pe.GID) + ":" +
-		pe.Comment + ":" +
-		pe.Home + ":" +
-		pe.Shell
-}
-
-// Parse parses a single line into a PasswdEntry struct.  Errors
-// are returned if the wrong number of fields are present in the input
-// string, or if the string contains illegal characters such as
-// newlines.
-func (pe *PasswdEntry) Parse(s string) error {
-	fields := strings.Split(s, ":")
-	if len(fields) != 7 {
-		return ErrWrongNumFields
-	}
-
-	pe.Login = fields[0]
-	pe.Password = fields[1]
-	pe.Comment = fields[4]
-	pe.Home = fields[5]
-	pe.Shell = fields[6]
-
-	uid, err := strconv.Atoi(fields[2])
-	if err != nil {
-		*pe = PasswdEntry{}
-		return ErrNotANumber
-	}
-	pe.UID = uid
-
-	gid, err := strconv.Atoi(fields[3])
-	if err != nil {
-		*pe = PasswdEntry{}
-		return ErrNotANumber
-	}
-	pe.GID = gid
-
-	return nil
-}
 
 // A PasswdMap is a complete set of passwd entries that can be written
 // and used as a list of entities on a system.

--- a/passwd_freebsd.go
+++ b/passwd_freebsd.go
@@ -1,0 +1,64 @@
+package shadow
+
+import (
+	"strconv"
+	"strings"
+)
+
+type PasswdEntry struct {
+	Login    string
+	Password string
+	UID      int
+	GID      int
+	Class    string
+	Change   string
+	Expire   string
+	Comment  string
+	Home     string
+	Shell    string
+}
+
+func (pe PasswdEntry) String() string {
+	return pe.Login + ":" +
+		pe.Password + ":" +
+		strconv.Itoa(pe.UID) + ":" +
+		strconv.Itoa(pe.GID) + ":" +
+		pe.Class + ":" +
+		pe.Change + ":" +
+		pe.Expire + ":" +
+		pe.Comment + ":" +
+		pe.Home + ":" +
+		pe.Shell
+}
+
+func (pe *PasswdEntry) Parse(s string) error {
+	fields := strings.Split(s, ":")
+	if len(fields) != 10 {
+		return ErrWrongNumFields
+	}
+
+	pe.Login = fields[0]
+	pe.Password = fields[1]
+	pe.Class = fields[4]
+	pe.Change = fields[5]
+	pe.Expire = fields[6]
+	pe.Comment = fields[7]
+	pe.Home = fields[8]
+	pe.Shell = fields[9]
+
+	uid, err := strconv.Atoi(fields[2])
+	if err != nil {
+		*pe = PasswdEntry{}
+		return ErrNotANumber
+	}
+	pe.UID = uid
+
+	gid, err := strconv.Atoi(fields[3])
+	if err != nil {
+		*pe = PasswdEntry{}
+		return ErrNotANumber
+	}
+	pe.GID = gid
+
+	return nil
+}

--- a/passwd_linux.go
+++ b/passwd_linux.go
@@ -1,0 +1,61 @@
+package shadow
+
+import (
+	"strconv"
+	"strings"
+)
+
+// A PasswdEntry represents a single entry in the passwd map.  The
+// entry uses the field names as found in `man 5 passwd`.
+type PasswdEntry struct {
+	Login    string
+	Password string
+	UID      int
+	GID      int
+	Comment  string
+	Home     string
+	Shell    string
+}
+
+func (pe PasswdEntry) String() string {
+	return pe.Login + ":" +
+		pe.Password + ":" +
+		strconv.Itoa(pe.UID) + ":" +
+		strconv.Itoa(pe.GID) + ":" +
+		pe.Comment + ":" +
+		pe.Home + ":" +
+		pe.Shell
+}
+
+// Parse parses a single line into a PasswdEntry struct.  Errors
+// are returned if the wrong number of fields are present in the input
+// string, or if the string contains illegal characters such as
+// newlines.
+func (pe *PasswdEntry) Parse(s string) error {
+	fields := strings.Split(s, ":")
+	if len(fields) != 7 {
+		return ErrWrongNumFields
+	}
+
+	pe.Login = fields[0]
+	pe.Password = fields[1]
+	pe.Comment = fields[4]
+	pe.Home = fields[5]
+	pe.Shell = fields[6]
+
+	uid, err := strconv.Atoi(fields[2])
+	if err != nil {
+		*pe = PasswdEntry{}
+		return ErrNotANumber
+	}
+	pe.UID = uid
+
+	gid, err := strconv.Atoi(fields[3])
+	if err != nil {
+		*pe = PasswdEntry{}
+		return ErrNotANumber
+	}
+	pe.GID = gid
+
+	return nil
+}


### PR DESCRIPTION
I have been experimenting with freebsd and netauth.
At the moment localizer won't work as bsd and linux passwd format slightly differs, this pr should rectify this.


Can be build tested with:
```
 GOOS=freebsd go build
 GOOS=linux go build
 ```